### PR TITLE
Updated to point client to monolith.

### DIFF
--- a/configs/nginx-ingress-aws-values.yml
+++ b/configs/nginx-ingress-aws-values.yml
@@ -11,6 +11,9 @@ controller:
       http: http
       https: http # SSL termination at the load balancer
     annotations:
+      meta.helm.sh/release-name: nginx
+      meta.helm.sh/release-namespace: default
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "<ACM Certificate ARN for SSL>"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-1:103947711118:certificate/239f9861-9dbd-4ca5-beff-7adad7eb1377"
 

--- a/xr3ngine/Chart.yaml
+++ b/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/xr3ngine/values.yaml
+++ b/xr3ngine/values.yaml
@@ -10,7 +10,7 @@ client:
 
   replicaCount: 1
   image:
-    repository: xr3ngine/xrsocial-client
+    repository: xr3ngine/xrsocial
     tag: latest
     pullPolicy: Always
 
@@ -20,7 +20,7 @@ client:
 
   service:
     type: ClusterIP
-    port: 3000
+    port: 3030
 
   ingress:
     enabled: true
@@ -35,7 +35,7 @@ client:
     #    hosts:
     #      - chart-example.local
 
-  
+
 
   serviceAccount:
     create: true
@@ -48,9 +48,11 @@ client:
   affinity: {}
   podSecurityContext: {}
   securityContext: {}
-  
+
   extraEnv:
     API_SERVER: http://xrsocial.local
+    CLIENT_ENABLED: "true"
+    SERVER_ENABLED: "false"
     SITE_TITLE: MyXR
     SITE_DESC: Connected Worlds for Everyone
     NODE_ENV: production
@@ -106,6 +108,9 @@ api:
     # ENV_VAR2: val2
 
     APP_HOST: http://api.xrsocial.local/
+
+    CLIENT_ENABLED: "false"
+    SERVER_ENABLED: "true"
 
     # automatically filled by chart.. ignore
     # MYSQL_PORT: 3306
@@ -198,6 +203,9 @@ media:
     # ENV_VAR2: val2
     
     APP_HOST: http://api.xrsocial.local/
+
+    CLIENT_ENABLED: "false"
+    SERVER_ENABLED: "true"
 
     # automatically filled by chart.. ignore
     # MYSQL_PORT: 3306


### PR DESCRIPTION
Updated values.yaml to have client point to monolith repo and be served from port 3030.

Added CLIENT_ENABLED and SERVER_ENABLED extraEnv's to everything except
spoke.

Added some annotations to nginx-ingress-aws-values.